### PR TITLE
support arrow 0.11.0 and jackson serialization configuration

### DIFF
--- a/arrow-integrations-jackson-module/src/main/kotlin/arrow/integrations/jackson/module/NonEmptyListModule.kt
+++ b/arrow-integrations-jackson-module/src/main/kotlin/arrow/integrations/jackson/module/NonEmptyListModule.kt
@@ -2,7 +2,6 @@ package arrow.integrations.jackson.module
 
 import arrow.core.NonEmptyList
 import arrow.core.getOrElse
-import arrow.core.toOption
 import com.fasterxml.jackson.core.json.PackageVersion
 import com.fasterxml.jackson.databind.BeanDescription
 import com.fasterxml.jackson.databind.DeserializationConfig
@@ -21,7 +20,7 @@ object NonEmptyListModule : SimpleModule(PackageVersion.VERSION) {
   init {
     addSerializer(
       NonEmptyList::class.java,
-      StdDelegatingSerializer(NonEmptyListSerializationConverter())
+      StdDelegatingSerializer(NonEmptyListSerializationConverter)
     )
   }
 
@@ -31,7 +30,7 @@ object NonEmptyListModule : SimpleModule(PackageVersion.VERSION) {
   }
 }
 
-class NonEmptyListSerializationConverter : StdConverter<NonEmptyList<*>, List<*>>() {
+object NonEmptyListSerializationConverter : StdConverter<NonEmptyList<*>, List<*>>() {
   override fun convert(value: NonEmptyList<*>?): List<*>? = value?.all.orEmpty()
 }
 
@@ -39,9 +38,7 @@ private class NonEmptyListDeserializationConverter(private val elementType: Java
   StdConverter<List<Any?>, NonEmptyList<Any?>?>() {
 
   override fun convert(value: List<*>?): NonEmptyList<*>? =
-    value.toOption()
-      .map { NonEmptyList.fromList(it).getOrElse { throw IllegalArgumentException("list is empty") } }
-      .orNull()
+    value?.let { NonEmptyList.fromList(it).getOrElse { throw IllegalArgumentException("NonEmptyList cannot be empty") } }
 
   override fun getInputType(typeFactory: TypeFactory): JavaType =
     typeFactory.constructCollectionType(List::class.java, elementType)

--- a/arrow-integrations-jackson-module/src/main/kotlin/arrow/integrations/jackson/module/NonEmptyListModule.kt
+++ b/arrow-integrations-jackson-module/src/main/kotlin/arrow/integrations/jackson/module/NonEmptyListModule.kt
@@ -1,7 +1,8 @@
 package arrow.integrations.jackson.module
 
-import arrow.core.Nel
-import arrow.syntax.function.pipe
+import arrow.core.NonEmptyList
+import arrow.core.getOrElse
+import arrow.core.toOption
 import com.fasterxml.jackson.core.json.PackageVersion
 import com.fasterxml.jackson.databind.BeanDescription
 import com.fasterxml.jackson.databind.DeserializationConfig
@@ -9,15 +10,19 @@ import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.deser.Deserializers
 import com.fasterxml.jackson.databind.deser.std.StdDelegatingDeserializer
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.ser.std.StdDelegatingSerializer
+import com.fasterxml.jackson.databind.type.CollectionType
 import com.fasterxml.jackson.databind.type.TypeFactory
 import com.fasterxml.jackson.databind.util.StdConverter
 
 object NonEmptyListModule : SimpleModule(PackageVersion.VERSION) {
-
   init {
-    addSerializer(Nel::class.java, StdDelegatingSerializer(NelSerializationConverter))
+    addSerializer(
+      NonEmptyList::class.java,
+      StdDelegatingSerializer(NonEmptyListSerializationConverter())
+    )
   }
 
   override fun setupModule(context: SetupContext) {
@@ -26,36 +31,37 @@ object NonEmptyListModule : SimpleModule(PackageVersion.VERSION) {
   }
 }
 
-private object NelSerializationConverter : StdConverter<Nel<*>, List<*>>() {
-  override fun convert(value: Nel<*>?): List<*>? = value?.all.orEmpty()
+class NonEmptyListSerializationConverter : StdConverter<NonEmptyList<*>, List<*>>() {
+  override fun convert(value: NonEmptyList<*>?): List<*>? = value?.all.orEmpty()
 }
 
-private class NelDeserializationConverter(private val elementType: JavaType) : StdConverter<List<Any?>, Nel<Any?>?>() {
+private class NonEmptyListDeserializationConverter(private val elementType: JavaType) :
+  StdConverter<List<Any?>, NonEmptyList<Any?>?>() {
 
-  override fun convert(value: List<*>?): Nel<*>? = value?.pipe { Nel.fromList(it).orNull() }
+  override fun convert(value: List<*>?): NonEmptyList<*>? =
+    value.toOption()
+      .map { NonEmptyList.fromList(it).getOrElse { throw IllegalArgumentException("list is empty") } }
+      .orNull()
 
   override fun getInputType(typeFactory: TypeFactory): JavaType =
     typeFactory.constructCollectionType(List::class.java, elementType)
 
   override fun getOutputType(typeFactory: TypeFactory): JavaType =
-    typeFactory.constructCollectionLikeType(Nel::class.java, elementType)
+    typeFactory.constructCollectionLikeType(NonEmptyList::class.java, elementType)
 }
 
-private object NonEmptyListDeserializerResolver : Deserializers.Base() {
+object NonEmptyListDeserializerResolver : Deserializers.Base() {
 
-  private val NON_EMPTY_LIST = Nel::class.java
-
-  override fun findBeanDeserializer(
-    type: JavaType,
+  override fun findCollectionDeserializer(
+    type: CollectionType,
     config: DeserializationConfig,
-    beanDesc: BeanDescription
-  ): JsonDeserializer<Nel<*>>? {
-    val rawClass = type.rawClass
-
-    return if (!NON_EMPTY_LIST.isAssignableFrom(rawClass)) {
-      null
+    beanDesc: BeanDescription,
+    elementTypeDeserializer: TypeDeserializer?,
+    elementDeserializer: JsonDeserializer<*>?
+  ): JsonDeserializer<NonEmptyList<*>>? =
+    if (NonEmptyList::class.java.isAssignableFrom(type.rawClass)) {
+      StdDelegatingDeserializer<NonEmptyList<*>>(NonEmptyListDeserializationConverter(type.bindings.getBoundType(0)))
     } else {
-      StdDelegatingDeserializer<Nel<*>>(NelDeserializationConverter(type.bindings.getBoundType(0)))
+      null
     }
-  }
 }

--- a/arrow-integrations-jackson-module/src/main/kotlin/arrow/integrations/jackson/module/OptionModule.kt
+++ b/arrow-integrations-jackson-module/src/main/kotlin/arrow/integrations/jackson/module/OptionModule.kt
@@ -2,135 +2,113 @@ package arrow.integrations.jackson.module
 
 import arrow.core.None
 import arrow.core.Option
-import arrow.syntax.function.pipe
+import arrow.core.getOrElse
+import arrow.core.or
 import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.core.JsonToken
 import com.fasterxml.jackson.core.json.PackageVersion
 import com.fasterxml.jackson.databind.BeanDescription
 import com.fasterxml.jackson.databind.BeanProperty
-import com.fasterxml.jackson.databind.DeserializationConfig
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.MapperFeature
+import com.fasterxml.jackson.databind.SerializationConfig
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer
-import com.fasterxml.jackson.databind.deser.Deserializers
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer
-import com.fasterxml.jackson.databind.jsontype.TypeDeserializer
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer
 import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.databind.ser.std.StdDelegatingSerializer
+import com.fasterxml.jackson.databind.ser.Serializers
+import com.fasterxml.jackson.databind.ser.std.ReferenceTypeSerializer
+import com.fasterxml.jackson.databind.type.ReferenceType
+import com.fasterxml.jackson.databind.type.TypeBindings
 import com.fasterxml.jackson.databind.type.TypeFactory
-import com.fasterxml.jackson.databind.util.StdConverter
+import com.fasterxml.jackson.databind.type.TypeModifier
+import com.fasterxml.jackson.databind.util.AccessPattern
+import com.fasterxml.jackson.databind.util.NameTransformer
+import java.lang.reflect.Type
 
 object OptionModule : SimpleModule(PackageVersion.VERSION) {
 
   init {
-    addSerializer(Option::class.java, StdDelegatingSerializer(OptionSerializationConverter))
+    addDeserializer(Option::class.java, OptionDeserializer())
   }
 
   override fun setupModule(context: SetupContext) {
     super.setupModule(context)
-    context.addDeserializers(OptionDeserializerResolver)
+    context.addSerializers(OptionSerializerResolver)
+    context.addTypeModifier(OptionTypeModifier)
   }
 }
 
-private object OptionSerializationConverter : StdConverter<Option<*>, Any>() {
-  override fun convert(value: Option<*>?): Any? = value?.orNull()
-}
-
-private class OptionDeserializer(
-  private val fullType: JavaType,
-  private val valueTypeDeserializer: TypeDeserializer?,
-  private val valueDeserializer: JsonDeserializer<*>?,
-  private val beanProperty: BeanProperty? = null
-) : StdDeserializer<Option<*>>(fullType), ContextualDeserializer {
-
-  override fun getValueType(): JavaType = fullType
-
-  override fun getNullValue(): Option<*> = None
-
-  private fun withResolved(
-    fullType: JavaType,
-    typeDeserializer: TypeDeserializer?,
-    valueDeserializer: JsonDeserializer<*>?,
-    beanProperty: BeanProperty?
-  ): OptionDeserializer {
-    return if (fullType == this.fullType &&
-      typeDeserializer == this.valueTypeDeserializer &&
-      valueDeserializer == this.valueDeserializer &&
-      beanProperty == this.beanProperty) {
-      this
+object OptionSerializerResolver : Serializers.Base() {
+  override fun findReferenceSerializer(
+    config: SerializationConfig,
+    type: ReferenceType,
+    beanDesc: BeanDescription?,
+    contentTypeSerializer: TypeSerializer?,
+    contentValueSerializer: JsonSerializer<Any>?
+  ): JsonSerializer<*>? =
+    if (Option::class.java.isAssignableFrom(type.rawClass)) {
+      val staticTyping = (contentTypeSerializer == null && config.isEnabled(MapperFeature.USE_STATIC_TYPING))
+      OptionSerializer(type, staticTyping, contentTypeSerializer, contentValueSerializer)
     } else {
-      OptionDeserializer(fullType, typeDeserializer, valueDeserializer, beanProperty)
-    }
-  }
-
-  override fun createContextual(ctxt: DeserializationContext, property: BeanProperty?): JsonDeserializer<Option<*>> {
-    val typeDeser = valueTypeDeserializer?.pipe { it.forProperty(property) }
-    var deser = valueDeserializer
-    var typ = fullType
-
-    fun refdType(): JavaType = typ.contentType ?: TypeFactory.unknownType()
-
-    if (deser == null) {
-      if (property != null) {
-        val intr = ctxt.annotationIntrospector
-        val member = property.member
-        if (intr != null && member != null) {
-          typ = intr.refineDeserializationType(ctxt.config, member, typ)
-        }
-        deser = ctxt.findContextualValueDeserializer(refdType(), property)
-      }
-    } else { // otherwise directly assigned, probably not contextual yet:
-      deser = ctxt.handleSecondaryContextualization(deser, property, refdType()) as JsonDeserializer<*>
-    }
-
-    return withResolved(typ, typeDeser, deser, property)
-  }
-
-  override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Option<*> {
-    val deser = valueDeserializer ?: ctxt.findContextualValueDeserializer(fullType.contentType, beanProperty)
-    val refd = valueTypeDeserializer?.pipe { deser.deserializeWithType(p, ctxt, it) } ?: deser.deserialize(p, ctxt)
-
-    return Option.fromNullable(refd)
-  }
-
-  override fun deserializeWithType(
-    jp: JsonParser,
-    ctxt: DeserializationContext,
-    typeDeserializer: TypeDeserializer
-  ): Option<*> {
-    val t = jp.currentToken
-    return if (t == JsonToken.VALUE_NULL) {
-      getNullValue(ctxt)
-    } else {
-      typeDeserializer.deserializeTypedFromAny(jp, ctxt) as Option<*>
-    }
-  }
-}
-
-private object OptionDeserializerResolver : Deserializers.Base() {
-
-  private val OPTION = Option::class.java
-
-  override fun findBeanDeserializer(
-    type: JavaType,
-    config: DeserializationConfig,
-    beanDesc: BeanDescription
-  ): JsonDeserializer<Option<*>>? {
-    val rawClass = type.rawClass
-
-    return if (!OPTION.isAssignableFrom(rawClass)) {
       null
-    } else {
-      val elementType: JavaType = type.bindings.getBoundType(0)
-
-      val typeDeser: TypeDeserializer? = elementType.getTypeHandler<TypeDeserializer>()
-      val valDeser: JsonDeserializer<*>? = elementType.getValueHandler()
-      OptionDeserializer(
-        config.typeFactory.constructReferenceType(Option::class.java, elementType),
-        typeDeser,
-        valDeser
-      )
     }
+}
+
+object OptionTypeModifier : TypeModifier() {
+  override fun modifyType(type: JavaType, jdkType: Type, context: TypeBindings?, typeFactory: TypeFactory?): JavaType = when {
+    type.isReferenceType || type.isContainerType -> type
+    type.rawClass == Option::class.java -> ReferenceType.upgradeFrom(type, type.containedTypeOrUnknown(0))
+    else -> type
   }
+}
+
+class OptionSerializer : ReferenceTypeSerializer<Option<*>> {
+  constructor(fullType: ReferenceType, staticTyping: Boolean, typeSerializer: TypeSerializer?, jsonSerializer: JsonSerializer<Any>?) :
+    super(fullType, staticTyping, typeSerializer, jsonSerializer)
+
+  constructor(
+    base: OptionSerializer,
+    property: BeanProperty?,
+    typeSerializer: TypeSerializer?,
+    valueSer: JsonSerializer<*>?,
+    unwrapper: NameTransformer?,
+    suppressableValue: Any?,
+    suppressNulls: Boolean
+  ) : super(base, property, typeSerializer, valueSer, unwrapper, suppressableValue, suppressNulls)
+
+  override fun withContentInclusion(suppressableValue: Any?, suppressNulls: Boolean): ReferenceTypeSerializer<Option<*>> =
+    OptionSerializer(this, _property, _valueTypeSerializer, _valueSerializer, _unwrapper, suppressableValue, suppressNulls)
+
+  override fun _isValuePresent(value: Option<*>): Boolean = value.isDefined()
+  override fun _getReferenced(value: Option<*>): Any? = value.orNull()
+  override fun _getReferencedIfPresent(value: Option<*>): Any? = value.orNull()
+  override fun withResolved(prop: BeanProperty?, vts: TypeSerializer?, valueSer: JsonSerializer<*>?, unwrapper: NameTransformer?):
+    ReferenceTypeSerializer<Option<*>> = OptionSerializer(this, prop, vts, valueSer, unwrapper, _suppressableValue, _suppressNulls)
+}
+
+class OptionDeserializer : JsonDeserializer<Option<*>>(), ContextualDeserializer {
+  private lateinit var valueType: JavaType
+  override fun deserialize(p: JsonParser?, ctxt: DeserializationContext): Option<*> =
+    Option.fromNullable(p).map {
+      ctxt.readValue<Any>(it, valueType)
+    }
+
+  override fun createContextual(ctxt: DeserializationContext, property: BeanProperty?): JsonDeserializer<*> {
+    val valueType = Option
+      .fromNullable(property)
+      .map { it.type.containedTypeOrUnknown(0) }
+      .or(Option.fromNullable(ctxt.contextualType?.containedTypeOrUnknown(0)))
+      .getOrElse { ctxt.constructType(Any::class.java) }
+
+    val deserializer = OptionDeserializer()
+    deserializer.valueType = valueType
+    return deserializer
+  }
+
+  override fun getNullValue(ctxt: DeserializationContext): Option<*> = None
+  override fun getEmptyValue(ctxt: DeserializationContext?): Option<*> = None
+  override fun getNullAccessPattern(): AccessPattern = AccessPattern.CONSTANT
+  override fun getEmptyAccessPattern(): AccessPattern = AccessPattern.CONSTANT
 }

--- a/arrow-integrations-jackson-module/src/test/kotlin/arrow/integrations/jackson/module/NonEmptyListModuleTest.kt
+++ b/arrow-integrations-jackson-module/src/test/kotlin/arrow/integrations/jackson/module/NonEmptyListModuleTest.kt
@@ -3,7 +3,6 @@ package arrow.integrations.jackson.module
 import arrow.core.Nel
 import arrow.core.test.UnitSpec
 import arrow.core.test.generators.nonEmptyList
-import arrow.syntax.function.pipe
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
@@ -34,9 +33,10 @@ class NonEmptyListModuleTest : UnitSpec() {
           Gen.nonEmptyList(Gen.bool()).map { it to jacksonTypeRef<Nel<Boolean>>() }
         )
       ) { (list, typeReference) ->
-        val roundTripped = mapper.writeValueAsString(list).pipe { mapper.readValue<Nel<*>>(it, typeReference) }
+        val encoded: String = mapper.writeValueAsString(list)
+        val decoded: Nel<Any> = mapper.readValue(encoded, typeReference)
 
-        roundTripped shouldBe list
+        decoded shouldBe list
       }
     }
   }

--- a/arrow-integrations-jackson-module/src/test/kotlin/arrow/integrations/jackson/module/NonEmptyListModuleTest.kt
+++ b/arrow-integrations-jackson-module/src/test/kotlin/arrow/integrations/jackson/module/NonEmptyListModuleTest.kt
@@ -39,5 +39,15 @@ class NonEmptyListModuleTest : UnitSpec() {
         decoded shouldBe list
       }
     }
+
+    "serializing NonEmptyList in an object should round trip" {
+      data class Wrapper(val nel: Nel<SomeObject>)
+      assertAll(Gen.nonEmptyList(Gen.someObject()).map { Wrapper(it) }) { wrapper ->
+        val encoded: String = mapper.writeValueAsString(wrapper)
+        val decoded: Wrapper = mapper.readValue(encoded, Wrapper::class.java)
+
+        decoded shouldBe wrapper
+      }
+    }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,7 @@ ROOT_PROJECT=https://raw.githubusercontent.com/arrow-kt/arrow/main/arrow-libs/gr
 SUB_PROJECT=https://raw.githubusercontent.com/arrow-kt/arrow/main/arrow-libs/gradle/subproject.gradle
 
 ARROW_VERSION=0.11.0
+JACKSON_MODULE_KOTLIN_VERSION=2.12.3
 
 # Gradle options
 org.gradle.jvmargs=-Xmx4g

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 rootProject.name = 'arrow-integrations-lib'
 
-// include 'arrow-integrations-jackson-module'
+include 'arrow-integrations-jackson-module'
 include 'arrow-integrations-retrofit-adapter'
 include 'arrow-docs'


### PR DESCRIPTION
closes #44
closes #46 

@rachelcarmena @raulraja this PR addresses 0.11.0 support. 

### In this PR
- upgrade jackson to 2.12.3 as earlier jackson versions may contain security vulnerabilities
- update Option codec so to make it honor object mapper configurations, this includes the NON_ABSENT inclusion

### To be addressed separately
- support for 0.12.0
- support for 0.13.x