### PR TITLE
Configuration: disable parallel execution

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ POM_DEVELOPER_NAME=The Arrow Authors
 
 # Gradle options
 org.gradle.jvmargs=-Xmx4g
-org.gradle.parallel=true
+org.gradle.parallel=false
 # To disable publishing of sha-512 checksums for maven-metadata.xml files
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 


### PR DESCRIPTION
It seems the reason of several staging repositories creation when publishing.