### PR TITLE
fix NonEmptyList deserialization failing on wildcard types

### DIFF
--- a/arrow-integrations-jackson-module/src/main/kotlin/arrow/integrations/jackson/module/NonEmptyListModule.kt
+++ b/arrow-integrations-jackson-module/src/main/kotlin/arrow/integrations/jackson/module/NonEmptyListModule.kt
@@ -62,9 +62,8 @@ public object NonEmptyListDeserializerResolver : Deserializers.Base() {
     elementDeserializer: JsonDeserializer<*>?
   ): JsonDeserializer<NonEmptyList<*>>? =
     if (NonEmptyList::class.java.isAssignableFrom(type.rawClass)) {
-      StdDelegatingDeserializer<NonEmptyList<*>>(
-        NonEmptyListDeserializationConverter(type.bindings.getBoundType(0))
-      )
+      val boundType = type.bindings.getBoundType(0) ?: config.constructType(Object::class.java)
+      StdDelegatingDeserializer<NonEmptyList<*>>(NonEmptyListDeserializationConverter(boundType))
     } else {
       null
     }

--- a/arrow-integrations-jackson-module/src/test/kotlin/arrow/integrations/jackson/module/EitherModuleTest.kt
+++ b/arrow-integrations-jackson-module/src/test/kotlin/arrow/integrations/jackson/module/EitherModuleTest.kt
@@ -9,6 +9,7 @@ import arrow.core.test.generators.option
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
@@ -85,6 +86,15 @@ class EitherModuleTest : FunSpec() {
               )
 
           testClass.shouldRoundTrip(mapper)
+        }
+      }
+
+      test("should round-trip on wildcard types") {
+        val mapper = ObjectMapper().registerArrowModule()
+        checkAll(Arb.either(Arb.int(1..10), Arb.string(5))) { original: Either<*, *> ->
+          val serialized = mapper.writeValueAsString(original)
+          val deserialized = shouldNotThrowAny { mapper.readValue(serialized, Either::class.java) }
+          deserialized shouldBe original
         }
       }
     }

--- a/arrow-integrations-jackson-module/src/test/kotlin/arrow/integrations/jackson/module/IorModuleTest.kt
+++ b/arrow-integrations-jackson-module/src/test/kotlin/arrow/integrations/jackson/module/IorModuleTest.kt
@@ -92,7 +92,9 @@ class IorModuleTest : FunSpec() {
         checkAll(Arb.ior(Arb.int(1..10), Arb.string(10, Codepoint.az()))) { original: Ior<*, *> ->
           val mapper = ObjectMapper().registerKotlinModule().registerArrowModule()
           val serialized = mapper.writeValueAsString(original)
-          val deserialized: Ior<*, *> = shouldNotThrowAny { mapper.readValue(serialized, Ior::class.java) }
+          val deserialized: Ior<*, *> = shouldNotThrowAny {
+            mapper.readValue(serialized, Ior::class.java)
+          }
           deserialized shouldBe original
         }
       }

--- a/arrow-integrations-jackson-module/src/test/kotlin/arrow/integrations/jackson/module/IorModuleTest.kt
+++ b/arrow-integrations-jackson-module/src/test/kotlin/arrow/integrations/jackson/module/IorModuleTest.kt
@@ -10,6 +10,7 @@ import arrow.core.test.generators.option
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
@@ -84,6 +85,15 @@ class IorModuleTest : FunSpec() {
               )
 
           testClass.shouldRoundTrip(mapper)
+        }
+      }
+
+      test("should round-trip with wildcard types") {
+        checkAll(Arb.ior(Arb.int(1..10), Arb.string(10, Codepoint.az()))) { original: Ior<*, *> ->
+          val mapper = ObjectMapper().registerKotlinModule().registerArrowModule()
+          val serialized = mapper.writeValueAsString(original)
+          val deserialized: Ior<*, *> = shouldNotThrowAny { mapper.readValue(serialized, Ior::class.java) }
+          deserialized shouldBe original
         }
       }
     }

--- a/arrow-integrations-jackson-module/src/test/kotlin/arrow/integrations/jackson/module/NonEmptyListModuleTest.kt
+++ b/arrow-integrations-jackson-module/src/test/kotlin/arrow/integrations/jackson/module/NonEmptyListModuleTest.kt
@@ -1,10 +1,13 @@
 package arrow.integrations.jackson.module
 
 import arrow.core.Nel
+import arrow.core.NonEmptyList
+import arrow.core.nonEmptyListOf
 import arrow.core.test.UnitSpec
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.arbitrary
@@ -53,6 +56,19 @@ class NonEmptyListModuleTest : UnitSpec() {
         val decoded: Wrapper = mapper.readValue(encoded, Wrapper::class.java)
 
         decoded shouldBe wrapper
+      }
+    }
+
+    "should round trip on NonEmptyList with wildcard type" {
+      val mapperWithSettings = ObjectMapper().registerKotlinModule().registerArrowModule()
+
+      checkAll(Arb.nonEmptyList(Arb.string())) { original: NonEmptyList<*> ->
+        val deserialized: NonEmptyList<*> = shouldNotThrowAny {
+          val serialized: String = mapperWithSettings.writeValueAsString(original)
+          mapperWithSettings.readValue(serialized, NonEmptyList::class.java)
+        }
+
+        deserialized shouldBe original
       }
     }
   }

--- a/arrow-integrations-jackson-module/src/test/kotlin/arrow/integrations/jackson/module/NonEmptyListModuleTest.kt
+++ b/arrow-integrations-jackson-module/src/test/kotlin/arrow/integrations/jackson/module/NonEmptyListModuleTest.kt
@@ -2,7 +2,6 @@ package arrow.integrations.jackson.module
 
 import arrow.core.Nel
 import arrow.core.NonEmptyList
-import arrow.core.nonEmptyListOf
 import arrow.core.test.UnitSpec
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonTypeRef

--- a/arrow-integrations-jackson-module/src/test/kotlin/arrow/integrations/jackson/module/OptionModuleTest.kt
+++ b/arrow-integrations-jackson-module/src/test/kotlin/arrow/integrations/jackson/module/OptionModuleTest.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.arbitrary
@@ -62,6 +63,15 @@ class OptionModuleTest : UnitSpec() {
         val decoded = mapper.readValue(encoded, typeReference)
 
         decoded shouldBe option
+      }
+    }
+
+    "should round-trip on wildcard types" {
+      val mapper = ObjectMapper().registerArrowModule()
+      checkAll(Arb.option(Arb.int(1..10))) { original: Option<*> ->
+        val serialized = mapper.writeValueAsString(original)
+        val deserialized = shouldNotThrowAny { mapper.readValue(serialized, Option::class.java) }
+        deserialized shouldBe original
       }
     }
   }

--- a/arrow-integrations-jackson-module/src/test/kotlin/arrow/integrations/jackson/module/ValidatedModuleTest.kt
+++ b/arrow-integrations-jackson-module/src/test/kotlin/arrow/integrations/jackson/module/ValidatedModuleTest.kt
@@ -83,12 +83,8 @@ class ValidatedModuleTest : FunSpec() {
       }
 
       test("should round-trip with wildcard types") {
-        checkAll(
-          Arb.validated(
-            Arb.int(1..10),
-            Arb.string(10, Codepoint.az())
-          )
-        ) { original: Validated<*, *> ->
+        checkAll(Arb.validated(Arb.int(1..10), Arb.string(10, Codepoint.az()))) {
+          original: Validated<*, *> ->
           val mapper = ObjectMapper().registerKotlinModule().registerArrowModule()
           val serialized = mapper.writeValueAsString(original)
           val deserialized: Validated<*, *> = shouldNotThrowAny {

--- a/arrow-integrations-jackson-module/src/test/kotlin/arrow/integrations/jackson/module/ValidatedModuleTest.kt
+++ b/arrow-integrations-jackson-module/src/test/kotlin/arrow/integrations/jackson/module/ValidatedModuleTest.kt
@@ -83,10 +83,17 @@ class ValidatedModuleTest : FunSpec() {
       }
 
       test("should round-trip with wildcard types") {
-        checkAll(Arb.validated(Arb.int(1..10), Arb.string(10, Codepoint.az()))) { original: Validated<*, *> ->
+        checkAll(
+          Arb.validated(
+            Arb.int(1..10),
+            Arb.string(10, Codepoint.az())
+          )
+        ) { original: Validated<*, *> ->
           val mapper = ObjectMapper().registerKotlinModule().registerArrowModule()
           val serialized = mapper.writeValueAsString(original)
-          val deserialized: Validated<*, *> = shouldNotThrowAny { mapper.readValue(serialized, Validated::class.java) }
+          val deserialized: Validated<*, *> = shouldNotThrowAny {
+            mapper.readValue(serialized, Validated::class.java)
+          }
           deserialized shouldBe original
         }
       }

--- a/arrow-integrations-jackson-module/src/test/kotlin/arrow/integrations/jackson/module/ValidatedModuleTest.kt
+++ b/arrow-integrations-jackson-module/src/test/kotlin/arrow/integrations/jackson/module/ValidatedModuleTest.kt
@@ -9,6 +9,7 @@ import arrow.core.valid
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
@@ -78,6 +79,15 @@ class ValidatedModuleTest : FunSpec() {
               .registerArrowModule(EitherModuleConfig(invalidFieldName, validFieldName))
 
           testClass.shouldRoundTrip(mapper)
+        }
+      }
+
+      test("should round-trip with wildcard types") {
+        checkAll(Arb.validated(Arb.int(1..10), Arb.string(10, Codepoint.az()))) { original: Validated<*, *> ->
+          val mapper = ObjectMapper().registerKotlinModule().registerArrowModule()
+          val serialized = mapper.writeValueAsString(original)
+          val deserialized: Validated<*, *> = shouldNotThrowAny { mapper.readValue(serialized, Validated::class.java) }
+          deserialized shouldBe original
         }
       }
     }


### PR DESCRIPTION
### In this PR
- fix missed nullability check on getBoundType
- added wildcard type tests for all modules

fixes #78 

