### PR TITLE
use arrow-gradle-config 0.10.3-alpha.3 to pickup java 8 source compatibility 

### DIFF
--- a/arrow-integrations-jackson-module/build.gradle.kts
+++ b/arrow-integrations-jackson-module/build.gradle.kts
@@ -8,6 +8,12 @@ plugins {
   `java-library`
 }
 
+java {
+  toolchain {
+    languageVersion.set(JavaLanguageVersion.of(8))
+  }
+}
+
 animalsniffer {
   sourceSets = sourceSets.find { it.name == "main" }?.let(::listOf).orEmpty() // Ignore tests
   ignore = listOf("java.lang.*")

--- a/arrow-integrations-jackson-module/build.gradle.kts
+++ b/arrow-integrations-jackson-module/build.gradle.kts
@@ -8,12 +8,6 @@ plugins {
   `java-library`
 }
 
-java {
-  toolchain {
-    languageVersion.set(JavaLanguageVersion.of(8))
-  }
-}
-
 animalsniffer {
   sourceSets = sourceSets.find { it.name == "main" }?.let(::listOf).orEmpty() // Ignore tests
   ignore = listOf("java.lang.*")

--- a/gradle/projects.libs.versions.toml
+++ b/gradle/projects.libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 arrow = "1.1.2"
 dokka = "1.6.21"
-arrowGradleConfig = "0.10.2"
+arrowGradleConfig = "0.10.3-alpha.3"
 kotlin = "1.6.21"
 kotest = "5.3.0"
 kotlinBinaryCompatibilityValidator = "0.10.0"


### PR DESCRIPTION
fixes #92 